### PR TITLE
If  is empty we are checking / with is_executable. This throws an error since we setup open_basedir properly

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -218,6 +218,9 @@ EOT;
                                 ->ifTrue(
                                     function ( $v )
                                     {
+                                        if (empty($v)) {
+                                            return false;
+                                        }
                                         $basename = basename( $v );
                                         // If there is a space in the basename, just drop it and everything after it.
                                         if ( ( $wsPos = strpos( $basename, ' ' ) ) !== false )


### PR DESCRIPTION


Error Message war in Test die folgende, kann man auch gern mal weiter debuggen warum es dazu kommt:

Warning: is_executable(): open_basedir restriction in effect. File(/) is not within the allowed path(s): (/var/www/srf-cms:/mnt/cms_cache_ramdisk:/mnt/cms_ezp_storage:/mnt/cms_ezp_session) in /var/www/srf-cms/vendor/netgen/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php on line 227